### PR TITLE
Add MAUI settings generation

### DIFF
--- a/samples/ClientAppsIntegration/Aspire.MAUIAppHost/Aspire.MAUIAppHost.csproj
+++ b/samples/ClientAppsIntegration/Aspire.MAUIAppHost/Aspire.MAUIAppHost.csproj
@@ -1,13 +1,10 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
+    <OutputType>Exe</OutputType>
     <TargetFramework>net8.0</TargetFramework>
     <ImplicitUsings>enable</ImplicitUsings>
     <Nullable>enable</Nullable>
   </PropertyGroup>
-
-  <ItemGroup>
-    <PackageReference Include="Aspire.Hosting" />
-  </ItemGroup>
 
 </Project>

--- a/samples/ClientAppsIntegration/Aspire.MAUIAppHost/Program.cs
+++ b/samples/ClientAppsIntegration/Aspire.MAUIAppHost/Program.cs
@@ -1,0 +1,86 @@
+﻿using System.Collections;
+
+namespace Aspire.MAUIAppHost;
+
+internal class Program
+{
+    public static void Main(string[] args)
+    {
+        IDictionary environmentVariables = Environment.GetEnvironmentVariables();
+
+        string? settingsPath = (string?)environmentVariables["ASPIRE_SETTINGS_PATH"];
+        if (settingsPath == null)
+        {
+            Console.Write("No ASPIRE_SETTINGS_PATH environment variable not found");
+        }
+        else
+        {
+            WriteSettings(environmentVariables, settingsPath);
+            Console.Write($"Updated {settingsPath}");
+        }
+
+        Thread.Sleep(Timeout.Infinite);
+    }
+
+    static void WriteSettings(IDictionary environmentVariables, string settingsPath)
+    {
+        var variablesToInclude = new HashSet<string> {
+            "ASPNETCORE_ENVIRONMENT",
+            "ASPNETCORE_URLS",
+            "DOTNET_ENVIRONMENT",
+            "DOTNET_LAUNCH_PROFILE",
+            "DOTNET_SYSTEM_CONSOLE_ALLOW_ANSI_COLOR_REDIRECTION"
+        };
+
+        // Get the subset of variables that are provided by Aspire and sort them
+        List<string> variableNames = new List<string>();
+        foreach (object variableNameObject in environmentVariables.Keys)
+        {
+            string variableName = (string)variableNameObject;
+            if (variablesToInclude.Contains(variableName) || variableName.StartsWith("OTEL_") || variableName.StartsWith("LOGGING__CONSOLE") || variableName.StartsWith("services__"))
+            {
+                variableNames.Add(variableName);
+            }
+        }
+        variableNames.Sort();
+
+        using (StreamWriter file = new StreamWriter(settingsPath))
+        {
+            file.Write("""
+                    // This file is generated from the Aspire AppHost project. Re-run the Aspre AppHost
+                    // to regenerate it.
+                    
+                    public static class AspireAppSettings
+                    {
+                        public static readonly Dictionary<string, string> Settings =
+                            new Dictionary<string, string>
+                            {
+
+                    """);
+
+            foreach (string variableName in variableNames)
+            {
+                string normalizedVariableName = variableName.Replace("__", ":");
+
+                string valueLiteral = GetValueStringLiteral((string) environmentVariables[variableName]!);
+                file.WriteLine($"""            ["{normalizedVariableName}"] = {valueLiteral},""");
+            }
+
+            file.Write("""
+                            };
+                    }
+                    """);
+        }
+    }
+
+    static string GetValueStringLiteral(string value)
+    {
+        // If the string contains a quote or escape sequence, use a verbatim string literal, where "" is used for "
+        if (value.Contains("\"") || value.Contains("\\"))
+        {
+            return "@\"" + value.Replace("\"", "\"\"") + "\"";
+        }
+        else return "\"" + value + "\"";
+    }
+}
+

--- a/samples/ClientAppsIntegration/AspireAppHostIntegration.MAUI/Class1.cs
+++ b/samples/ClientAppsIntegration/AspireAppHostIntegration.MAUI/Class1.cs
@@ -1,7 +1,0 @@
-﻿namespace AspireAppHostIntegration.MAUI
-{
-    public class Class1
-    {
-
-    }
-}

--- a/samples/ClientAppsIntegration/AspireAppHostIntegration.MAUI/MauiProjectResourceBuilderExtension.cs
+++ b/samples/ClientAppsIntegration/AspireAppHostIntegration.MAUI/MauiProjectResourceBuilderExtension.cs
@@ -1,0 +1,43 @@
+﻿using System.Net.Sockets;
+using Aspire.Hosting;
+using Aspire.Hosting.Publishing;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Logging;
+
+namespace Aspire.Hosting;
+
+public static class MauiProjectResourceBuilderExtension
+{
+    /// <summary>
+    /// Adds a .NET project to the application model. 
+    /// </summary>
+    /// <param name="builder">The <see cref="IDistributedApplicationBuilder"/>.</param>
+    /// <param name="name">The name of the resource. This name will be used for service discovery when referenced in a dependency.</param>
+    /// <param name="projectDirectory">The path to the project file.</param>
+    /// <returns>A reference to the <see cref="IResourceBuilder{ProjectResource}"/>.</returns>
+    public static IResourceBuilder<ProjectResource> AddMauiProject(this IDistributedApplicationBuilder builder, string name, string projectDirectory,
+        string settingsFileName = "AspireAppSettings.g.cs")
+    {
+        string settingsPath = NormalizePathForCurrentPlatform(Path.Combine(builder.AppHostDirectory, projectDirectory, settingsFileName));
+        string mauiAppHostPath = NormalizePathForCurrentPlatform(Path.Combine(builder.AppHostDirectory, "../Aspire.MAUIAppHost/Aspire.MAUIAppHost.csproj"));
+
+        return builder.AddProject(name, "../Aspire.MAUIAppHost/Aspire.MAUIAppHost.csproj")
+           .WithEnvironment(context =>
+           {
+               context.EnvironmentVariables.Add("ASPIRE_SETTINGS_PATH", settingsPath);
+           });
+    }
+
+    private static string NormalizePathForCurrentPlatform(string path)
+    {
+        if (string.IsNullOrEmpty(path))
+        {
+            return path;
+        }
+
+        // Fix slashes
+        path = path.Replace('\\', Path.DirectorySeparatorChar).Replace('/', Path.DirectorySeparatorChar);
+
+        return Path.GetFullPath(path);
+    }
+}

--- a/samples/ClientAppsIntegration/ClientAppsIntegration-MAUI.sln
+++ b/samples/ClientAppsIntegration/ClientAppsIntegration-MAUI.sln
@@ -23,7 +23,9 @@ Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "ClientAppsIntegration.MAUI"
 EndProject
 Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "AspireAppHostIntegration.MAUI", "AspireAppHostIntegration.MAUI\AspireAppHostIntegration.MAUI.csproj", "{74660E83-9B4A-45C8-8D56-4617AE692F18}"
 EndProject
-Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "AspireAppClientIntegration.MAUI", "AspireAppClientIntegration.MAUI\AspireAppClientIntegration.MAUI.csproj", "{43370191-9790-4BAA-B29B-A841A13E5BFE}"
+Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "AspireAppClientIntegration.MAUI", "AspireAppClientIntegration.MAUI\AspireAppClientIntegration.MAUI.csproj", "{43370191-9790-4BAA-B29B-A841A13E5BFE}"
+EndProject
+Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "Aspire.MAUIAppHost", "Aspire.MAUIAppHost\Aspire.MAUIAppHost.csproj", "{926F21F9-FF3F-47C3-9E91-3D18BCF55660}"
 EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
@@ -57,6 +59,7 @@ Global
 		{76286010-2AB5-4E42-B490-BC87E5595DE6}.Release|Any CPU.Build.0 = Release|Any CPU
 		{08D8752D-0D3D-400D-9872-A7C950EA3464}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
 		{08D8752D-0D3D-400D-9872-A7C950EA3464}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{08D8752D-0D3D-400D-9872-A7C950EA3464}.Debug|Any CPU.Deploy.0 = Debug|Any CPU
 		{08D8752D-0D3D-400D-9872-A7C950EA3464}.Release|Any CPU.ActiveCfg = Release|Any CPU
 		{08D8752D-0D3D-400D-9872-A7C950EA3464}.Release|Any CPU.Build.0 = Release|Any CPU
 		{74660E83-9B4A-45C8-8D56-4617AE692F18}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
@@ -67,6 +70,10 @@ Global
 		{43370191-9790-4BAA-B29B-A841A13E5BFE}.Debug|Any CPU.Build.0 = Debug|Any CPU
 		{43370191-9790-4BAA-B29B-A841A13E5BFE}.Release|Any CPU.ActiveCfg = Release|Any CPU
 		{43370191-9790-4BAA-B29B-A841A13E5BFE}.Release|Any CPU.Build.0 = Release|Any CPU
+		{926F21F9-FF3F-47C3-9E91-3D18BCF55660}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{926F21F9-FF3F-47C3-9E91-3D18BCF55660}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{926F21F9-FF3F-47C3-9E91-3D18BCF55660}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{926F21F9-FF3F-47C3-9E91-3D18BCF55660}.Release|Any CPU.Build.0 = Release|Any CPU
 	EndGlobalSection
 	GlobalSection(SolutionProperties) = preSolution
 		HideSolutionNode = FALSE

--- a/samples/ClientAppsIntegration/ClientAppsIntegration.AppHost/ClientAppsIntegration.AppHost.csproj
+++ b/samples/ClientAppsIntegration/ClientAppsIntegration.AppHost/ClientAppsIntegration.AppHost.csproj
@@ -9,10 +9,11 @@
   </PropertyGroup>
 
   <ItemGroup>
+    <ProjectReference Include="..\Aspire.MAUIAppHost\Aspire.MAUIAppHost.csproj" />
+    <ProjectReference Include="..\AspireAppHostIntegration.MAUI\AspireAppHostIntegration.MAUI.csproj" />
     <ProjectReference Include="..\ClientAppsIntegration.ApiService\ClientAppsIntegration.ApiService.csproj" />
     <ProjectReference Include="..\ClientAppsIntegration.WinForms\ClientAppsIntegration.WinForms.csproj" SkipGetTargetFrameworkProperties="true" ReferenceOutputAssembly="false" />
     <ProjectReference Include="..\ClientAppsIntegration.WPF\ClientAppsIntegration.WPF.csproj" SkipGetTargetFrameworkProperties="true" ReferenceOutputAssembly="false" />
-    <ProjectReference Include="..\ClientAppsIntegration.MAUI\ClientAppsIntegration.MAUI.csproj" SkipGetTargetFrameworkProperties="true" ReferenceOutputAssembly="false" />
   </ItemGroup>
 
   <ItemGroup>

--- a/samples/ClientAppsIntegration/ClientAppsIntegration.AppHost/Program.cs
+++ b/samples/ClientAppsIntegration/ClientAppsIntegration.AppHost/Program.cs
@@ -9,9 +9,9 @@ builder.AddProject("winformsclient", "../ClientAppsIntegration.WinForms/ClientAp
     .WithReference(apiService);
 
 builder.AddProject("wpfclient", "../ClientAppsIntegration.WPF/ClientAppsIntegration.WPF.csproj")
-    .WithReference(apiService); 
+    .WithReference(apiService);
 
-builder.AddProject("mauiclient", "../ClientAppsIntegration.MAUI/ClientAppsIntegration.MAUI.csproj")
+builder.AddMauiProject("mauiclient", "../ClientAppsIntegration.MAUI")
    .WithReference(apiService);
 
 builder.Build().Run();

--- a/samples/ClientAppsIntegration/ClientAppsIntegration.MAUI/AspireAppSettings.g.cs
+++ b/samples/ClientAppsIntegration/ClientAppsIntegration.MAUI/AspireAppSettings.g.cs
@@ -1,16 +1,23 @@
-﻿namespace ClientAppsIntegration.MAUI
+// This file is generated from the Aspire AppHost project. Re-run the Aspre AppHost
+// to regenerate it.
+
+public static class AspireAppSettings
 {
-    public static class AspireAppSettings
-    {
-        // TODO: Update to set correct settings here, same as set in environment variables for e.g. WPF & WinForms clients
-        // Later will be generated.
-        public static readonly Dictionary<string, string> Settings =
-            new Dictionary<string, string>
+    public static readonly Dictionary<string, string> Settings =
+        new Dictionary<string, string>
         {
-            ["SecretKey"] = "Dictionary MyKey Value",
-            ["TransientFaultHandlingOptions:Enabled"] = bool.TrueString,
-            ["TransientFaultHandlingOptions:AutoRetryDelay"] = "00:00:07",
-            ["Logging:LogLevel:Default"] = "Warning"
+            ["DOTNET_SYSTEM_CONSOLE_ALLOW_ANSI_COLOR_REDIRECTION"] = "true",
+            ["LOGGING:CONSOLE:FORMATTERNAME"] = "simple",
+            ["LOGGING:CONSOLE:FORMATTEROPTIONS:TIMESTAMPFORMAT"] = "yyyy-MM-ddTHH:mm:ss.fffffff ",
+            ["OTEL_BLRP_SCHEDULE_DELAY"] = "1000",
+            ["OTEL_BSP_SCHEDULE_DELAY"] = "1000",
+            ["OTEL_DOTNET_EXPERIMENTAL_OTLP_EMIT_EVENT_LOG_ATTRIBUTES"] = "true",
+            ["OTEL_DOTNET_EXPERIMENTAL_OTLP_EMIT_EXCEPTION_LOG_ATTRIBUTES"] = "true",
+            ["OTEL_EXPORTER_OTLP_ENDPOINT"] = "http://localhost:16222",
+            ["OTEL_METRIC_EXPORT_INTERVAL"] = "1000",
+            ["OTEL_RESOURCE_ATTRIBUTES"] = "service.instance.id=1067693a-ce1b-4fa0-8bb1-7f22f1678cd9",
+            ["OTEL_SERVICE_NAME"] = "mauiclient",
+            ["services:apiservice:0"] = "http://_http.localhost:5303",
+            ["services:apiservice:1"] = "http://localhost:5303",
         };
-    }
 }

--- a/samples/ClientAppsIntegration/ClientAppsIntegration.MAUI/ClientAppsIntegration.MAUI.csproj
+++ b/samples/ClientAppsIntegration/ClientAppsIntegration.MAUI/ClientAppsIntegration.MAUI.csproj
@@ -1,6 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
 	<PropertyGroup>
+		<TargetFrameworks>net8.0-android;net8.0-ios;net8.0-maccatalyst</TargetFrameworks>
     <TargetFrameworks Condition="$([MSBuild]::IsOSPlatform('windows'))">$(TargetFrameworks);net8.0-windows10.0.19041.0</TargetFrameworks>
 		<!-- Uncomment to also build the tizen app. You will need to install tizen by following this: https://github.com/Samsung/Tizen.NET -->
 		<!-- <TargetFrameworks>$(TargetFrameworks);net8.0-tizen</TargetFrameworks> -->
@@ -12,6 +13,7 @@
 		either BOTH runtimes must be indicated or ONLY macatalyst-x64. -->
 		<!-- For example: <RuntimeIdentifiers>maccatalyst-x64;maccatalyst-arm64</RuntimeIdentifiers> -->
 
+    <ManagePackageVersionsCentrally>false</ManagePackageVersionsCentrally>
 		<OutputType>Exe</OutputType>
 		<RootNamespace>ClientAppsIntegration.MAUI</RootNamespace>
 		<UseMaui>true</UseMaui>
@@ -65,10 +67,10 @@
 	</ItemGroup>
 
 	<ItemGroup>
-		<PackageReference Include="Microsoft.Maui.Controls" />
-		<PackageReference Include="Microsoft.Maui.Controls.Compatibility" />
-		<PackageReference Include="Microsoft.Extensions.Logging.Debug" />
-    <PackageReference Include="Microsoft.Extensions.Hosting" />
+		<PackageReference Include="Microsoft.Maui.Controls" Version="$(MauiVersion)" />
+		<PackageReference Include="Microsoft.Maui.Controls.Compatibility" Version="$(MauiVersion)" />
+		<PackageReference Include="Microsoft.Extensions.Logging.Debug" Version="8.0.0" />
+    <PackageReference Include="Microsoft.Extensions.Hosting" Version="8.0.0" />
 	</ItemGroup>
 
 	<ItemGroup>

--- a/samples/ClientAppsIntegration/ClientAppsIntegration.MAUI/MauiProgram.cs
+++ b/samples/ClientAppsIntegration/ClientAppsIntegration.MAUI/MauiProgram.cs
@@ -20,6 +20,9 @@ namespace ClientAppsIntegration.MAUI
                 });
 
             var wrapperMauiAppBuilder = new WrapperMauiAppBuilder(mauiAppBuilder);
+#if DEBUG
+            wrapperMauiAppBuilder.Configuration.AddInMemoryCollection(AspireAppSettings.Settings);
+#endif
 
             wrapperMauiAppBuilder.AddAppDefaults();
 


### PR DESCRIPTION
Update MAUI integration, doing settings generation. Here's how it works:
- Launching the AppHost launches the stub Aspire.MAUIAppHost project instead of the real MAUI app. This stub generates/updates the Aspire settings, normally passed as environment variables, in the AspireAppSettings.g.cs source file in the MAUI client app repo. That allows these settings to be included MAUI app build time.
- When the MAUI app itself is launched (separately), it populates its IConfiguration config based on AspireAppSettings.g.cs, and thus knows how to connect to apiservice and the OpenTelemetry provider, do service discovery, etc., since the same config settings normally provided by an EnvironmentVariablesConfigurationProvider are provided by a MemoryConfigurationProvider.
- If the Aspire settings change, AppHost need to be relaunched to regenerate. But fortunately, the settings tend to be stable, not changing on every run.